### PR TITLE
Drop old GHC

### DIFF
--- a/digest.cabal
+++ b/digest.cabal
@@ -19,11 +19,6 @@ extra-source-files:
   testing/trivial.expected
   testing/trivial.hs
 
-flag bytestring-in-base
-  description: In the ghc-6.6 era the bytestring modules were
-               included in the base package.
-  default: False
-
 source-repository head
   type: git
   location: git://github.com/jkff/digest
@@ -33,13 +28,9 @@ library
                    Data.Digest.Adler32
   default-extensions: CPP, ForeignFunctionInterface
   default-language: Haskell2010
-  build-depends: base < 5
-  if flag(bytestring-in-base)
-    -- bytestring was in base-2.0 and 2.1.1
-    build-depends: base >= 2.0 && < 2.2
-    cpp-options: -DBYTESTRING_IN_BASE
-  else
-    build-depends: base < 2.0 || >= 2.2, bytestring >= 0.9
+  build-depends: 
+    base < 5
+    , bytestring >= 0.9 && < 2.2
   includes:        zlib.h
   ghc-options:     -Wall
   if !os(windows)


### PR DESCRIPTION
Drop some parts of the cabal file that are only required for very old GHC.
