### PR TITLE
Remove mentions of 'cryptographic hashes'

### DIFF
--- a/digest.cabal
+++ b/digest.cabal
@@ -6,8 +6,8 @@ license-file:    LICENSE
 author:          Eugene Kirpichov <ekirpichov@gmail.com>
 maintainer:      Eugene Kirpichov <ekirpichov@gmail.com>
 category:        Cryptography
-synopsis:        Various cryptographic hashes for bytestrings; CRC32 and Adler32 for now.
-description:     This package provides efficient cryptographic hash implementations for  
+synopsis:        Various hashes for bytestrings; CRC32 and Adler32 for now.
+description:     This package provides efficient hash implementations for  
                  strict and lazy bytestrings. For now, CRC32 and Adler32 are supported; 
                  they are implemented as FFI bindings to efficient code from zlib.
 stability:       provisional


### PR DESCRIPTION
It's a bit of a misnomer apparently to call these 'cryptographic' hashes