### PR TITLE
Use https for git source repository

### DIFF
--- a/digest.cabal
+++ b/digest.cabal
@@ -26,7 +26,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: git://github.com/TeofilC/digest
+  location: https://github.com/TeofilC/digest
 
 library
   exposed-modules: Data.Digest.CRC32,


### PR DESCRIPTION
`git://` is deprecated and no longer supported.