### PR TITLE
Introduce 'pkg-config' cabal flag

### DIFF
--- a/digest.cabal
+++ b/digest.cabal
@@ -25,6 +25,11 @@ extra-source-files:
   testing/trivial.hs
   CHANGELOG.md
 
+flag pkg-config
+  default:     True
+  manual:      True
+  description: Use @pkg-config(1)@ to locate @zlib@ library.
+
 source-repository head
   type: git
   location: https://github.com/TeofilC/digest
@@ -39,7 +44,7 @@ library
     , bytestring >= 0.9 && < 0.12
   includes:        zlib.h
   ghc-options:     -Wall
-  if !os(windows)
+  if flag(pkg-config) && !os(windows)
     pkgconfig-depends: zlib
   else
     build-depends: zlib


### PR DESCRIPTION
Unfortunately using pkg-config https://github.com/jkff/digest/pull/5 doesn't seem to play nicely with Bazel (using [rules_haskell](https://github.com/tweag/rules_haskell)).

If we add a flag that default to `True` this should preserve the existing behaviour, but also allow users to opt out.

This is similar to [`regex-pcre`](https://github.com/haskell-hvr/regex-pcre/blob/61ac5d7394dee3cf5addb645aa64b0ddde8efd68/regex-pcre.cabal#L42-L45).