### PR TITLE
Do not use pkg-config to locate zlib on FreeBSD

### DIFF
--- a/digest.cabal
+++ b/digest.cabal
@@ -44,7 +44,7 @@ library
     , bytestring >= 0.9 && < 0.12
   includes:        zlib.h
   ghc-options:     -Wall
-  if flag(pkg-config) && !os(windows)
+  if flag(pkg-config) && !os(windows) && !os(freebsd)
     pkgconfig-depends: zlib
   else
     build-depends: zlib


### PR DESCRIPTION
FreeBSD has zlib in its base system, so it is guaranteed to be present. At the same time it doesn't provide a .pc file, so Cabal fails to fullfill the `pkgconfig-depends: zlib` dependency.