### PR TITLE
Make pkgconfig an automatic flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.2.1 — 10th Febraury 2024
+- Make pkg-config an automatic flag: <https://github.com/TeofilC/digest/pull/21>
+
 ## 0.0.2.0 — 13th December 2023
 - Add CRC32C (Thanks to @4eUep): <https://github.com/TeofilC/digest/pull/18>
 - Support latest GHC versions: <https://github.com/TeofilC/digest/pull/19>

--- a/digest.cabal
+++ b/digest.cabal
@@ -28,7 +28,7 @@ extra-source-files:
 
 flag pkg-config
   default:     True
-  manual:      True
+  manual:      False
   description: Use @pkg-config(1)@ to locate @zlib@ library.
 
 -- TODO: auto detect

--- a/digest.cabal
+++ b/digest.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               digest
-version:            0.0.2.0
+version:            0.0.2.1
 copyright:          (c) 2009 Eugene Kirpichov
 license:            BSD-2-Clause
 license-file:       LICENSE


### PR DESCRIPTION
This means that if we fail to find zlib using pkgconfig, then cabal will retry using other means. -m Resolves