### PR TITLE
Depend on `crc32c` package

### DIFF
--- a/digest.cabal
+++ b/digest.cabal
@@ -31,51 +31,6 @@ flag pkg-config
   manual:      False
   description: Use @pkg-config(1)@ to locate @zlib@ library.
 
--- TODO: auto detect
-flag have_builtin_prefetch
-  default:     False
-  manual:      True
-  description: The cxx compiler has the __builtin_prefetch intrinsic.
-
--- TODO: auto detect
-flag have_mm_prefetch
-  default:     False
-  manual:      True
-  description:
-    Targeting X86 and the compiler has the _mm_prefetch intrinsic.
-
--- TODO: auto detect
-flag have_sse42
-  default:     False
-  manual:      True
-  description:
-    Can be enabled to improve performance of CRC32C if targeting X86 and
-    the compiler has the _mm_crc32_u{8,32,64} intrinsics.
-
--- TODO: auto detect
-flag have_arm64_crc32c
-  default:     False
-  manual:      True
-  description:
-    Targeting ARM and the compiler has the __crc32c{b,h,w,d} and the
-    vmull_p64 intrinsics.
-
--- TODO: auto detect
-flag have_strong_getauxval
-  default:     False
-  manual:      True
-  description:
-    The system libraries have the getauxval function in the <sys/auxv.h> header.
-    Should be true on Linux and Android API level 20+.
-
--- TODO: auto detect
-flag have_weak_getauxval
-  default:     False
-  manual:      True
-  description:
-    The compiler supports defining getauxval as a weak symbol.
-    Should be true for any compiler that supports __attribute__((weak)).
-
 source-repository head
   type:     git
   location: https://github.com/TeofilC/digest
@@ -89,38 +44,15 @@ library
   default-extensions:
     CPP
     ForeignFunctionInterface
+    PackageImports
 
   default-language:   Haskell2010
   build-depends:
     , base        >=4.12 && <5
     , bytestring  >=0.10 && <0.13
+    , crc32c    
 
   includes:           zlib.h
-  include-dirs:       include external/crc32c/include
-  cxx-options:        -std=c++11
-  cxx-sources:
-    external/crc32c/src/crc32c.cc
-    external/crc32c/src/crc32c_portable.cc
-
-  if flag(have_builtin_prefetch)
-    cxx-options: -DHAVE_BUILTIN_PREFETCH
-
-  if flag(have_mm_prefetch)
-    cxx-options: -DHAVE_MM_PREFETCH
-
-  if (arch(x86_64) && flag(have_sse42))
-    cxx-options: -DHAVE_SSE42 -msse4.2
-    cxx-sources: external/crc32c/src/crc32c_sse42.cc
-
-  if (arch(aarch64) && flag(have_arm64_crc32c))
-    cxx-options: -DHAVE_ARM64_CRC32C
-    cxx-sources: external/crc32c/src/crc32c_arm64.cc
-
-  if flag(have_strong_getauxval)
-    cxx-options: -DHAVE_STRONG_GETAUXVAL
-
-  if flag(have_weak_getauxval)
-    cxx-options: -DHAVE_WEAK_GETAUXVAL
 
   ghc-options:        -Wall
 


### PR DESCRIPTION
When cross-compiling to Windows `ouroboros-consensus` using Haskell.nix, we encountered the following error:

```
GHC runtime linker: fatal error: I found a duplicate definition for symbol
    _ZN6crc32c6ExtendEjPKhy
whilst processing object file
/nix/store/8qz5kdvkm4cwx3lp8va8qg7bcd37597a-crc32c-lib-crc32c-x86_64-w64-mingw32-0.2.2/lib/x86_64-windows-ghc-9.6.7/crc32c-0.2.2-64Ea6b7xkwZIBzf0wemhyo/HScrc32c-0.2.2-64Ea6b7xkwZIBzf0wemhyo.o

The symbol was previously defined in
/nix/store/1cxcd8cdfbj9mmzbxxdmi8n82imk39g8-digest-lib-digest-x86_64-w64-mingw32-0.0.2.1/lib/x86_64-windows-ghc-9.6.7/digest-0.0.2.1-2QlBcNaJoyYSlQnmZZr6h/HSdigest-0.0.2.1-2QlBcNaJoyYSlQnmZZr6h.o

This could be caused by:
  * Loading two different object files which export the same symbol
  * Specifying the same object file twice on the GHCi command line
  * An incorrect `package.conf' entry, causing some object to be loaded twice.

iserv-proxy-interpreter.exe: loadObj "/nix/store/8qz5kdvkm4cwx3lp8va8qg7bcd37597a-crc32c-lib-crc32c-x86_64-w64-mingw32-0.2.2/lib/x86_64-windows-ghc-9.6.7/crc32c-0.2.2-64Ea6b7xkwZIBzf0wemhyo/HScrc32c-0.2.2-64Ea6b7xkwZIBzf0wemhyo.o": failed
```

The veredict is that both `crc32c` and `digest` (on which we depend via different dependencies) compile C sources for libcrc32c, and they both expose the same symbols. In a normal Windows build this is not a problem, but it is a problem for the cross-compilation.

`digest` has a git submodule with Google's crc32c, and `crc32c` instead has a local vendored version of the source code.

A possible alternative would be to create a package that prepares the C sources for both `crc32c` and `digest`. In the same spirit as https://hackage.haskell.org/package/zlib-clib.

I'm opening this PR as a way to start the discussion on how to best solve this. Unfortunately `digest` exposed quite some cabal flags which do not exist in `crc32c`, so I don't really know how to best proceed.